### PR TITLE
Add Symfony 5 compatibility

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -25,8 +25,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('ongr_elasticsearch');
+        $treeBuilder = new TreeBuilder('ongr_elasticsearch');
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('fos_rest');
+        }
 
         $rootNode
             ->children()
@@ -56,8 +61,13 @@ class Configuration implements ConfigurationInterface
      */
     private function getAnalysisNode()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('analysis');
+        $treeBuilder = new TreeBuilder('analysis');
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $node = $treeBuilder->getRootNode();
+        } else {
+            $node = $treeBuilder->root('analysis');
+        }
 
         $node
             ->info('Defines analyzers, normalizers, tokenizers and filters')
@@ -95,8 +105,13 @@ class Configuration implements ConfigurationInterface
      */
     private function getManagersNode()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('managers');
+        $treeBuilder = new TreeBuilder('managers');
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $node = $treeBuilder->getRootNode();
+        } else {
+            $node = $treeBuilder->root('managers');
+        }
 
         $node
             ->isRequired()

--- a/Event/BaseEvent.php
+++ b/Event/BaseEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\Event as ContractsEvent;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
+
+// Clean up when sf 3.4 support is removed
+if (is_subclass_of(EventDispatcherInterface::class, ContractsEventDispatcherInterface::class)) {
+    /**
+     * @internal
+     */
+    abstract class BaseEvent extends ContractsEvent
+    {
+    }
+} else {
+    /**
+     * @internal
+     */
+    abstract class BaseEvent extends Event
+    {
+    }
+}

--- a/Event/BulkEvent.php
+++ b/Event/BulkEvent.php
@@ -11,9 +11,7 @@
 
 namespace ONGR\ElasticsearchBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
-
-class BulkEvent extends Event
+class BulkEvent extends BaseEvent
 {
     /**
      * @var string

--- a/Event/CommitEvent.php
+++ b/Event/CommitEvent.php
@@ -11,9 +11,7 @@
 
 namespace ONGR\ElasticsearchBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
-
-class CommitEvent extends Event
+class CommitEvent extends BaseEvent
 {
     /**
      * @var string

--- a/Event/PostCreateManagerEvent.php
+++ b/Event/PostCreateManagerEvent.php
@@ -12,9 +12,8 @@
 namespace ONGR\ElasticsearchBundle\Event;
 
 use ONGR\ElasticsearchBundle\Service\Manager;
-use Symfony\Component\EventDispatcher\Event;
 
-class PostCreateManagerEvent extends Event
+class PostCreateManagerEvent extends BaseEvent
 {
     /**
      * @var Manager

--- a/Event/PreCreateManagerEvent.php
+++ b/Event/PreCreateManagerEvent.php
@@ -12,9 +12,8 @@
 namespace ONGR\ElasticsearchBundle\Event;
 
 use Elasticsearch\ClientBuilder;
-use Symfony\Component\EventDispatcher\Event;
 
-class PreCreateManagerEvent extends Event
+class PreCreateManagerEvent extends BaseEvent
 {
     /**
      * @var ClientBuilder

--- a/Event/PrePersistEvent.php
+++ b/Event/PrePersistEvent.php
@@ -11,9 +11,7 @@
 
 namespace ONGR\ElasticsearchBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
-
-class PrePersistEvent extends Event
+class PrePersistEvent extends BaseEvent
 {
     /**
      * @var object

--- a/Profiler/ElasticsearchProfiler.php
+++ b/Profiler/ElasticsearchProfiler.php
@@ -52,7 +52,7 @@ class ElasticsearchProfiler extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function collect(Request $request, Response $response, \Exception $exception = null)
+    public function collect(Request $request, Response $response, $exception = null)
     {
         /** @var Logger $logger */
         foreach ($this->loggers as $logger) {

--- a/Test/AbstractElasticsearchTestCase.php
+++ b/Test/AbstractElasticsearchTestCase.php
@@ -13,6 +13,7 @@ namespace ONGR\ElasticsearchBundle\Test;
 
 use ONGR\ElasticsearchBundle\Service\Manager;
 use ONGR\ElasticsearchBundle\Tests\WebTestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -20,6 +21,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 abstract class AbstractElasticsearchTestCase extends WebTestCase
 {
+    use SetUpTearDownTrait;
+
     /**
      * @var Manager[] Holds used managers.
      */
@@ -33,7 +36,7 @@ abstract class AbstractElasticsearchTestCase extends WebTestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function doSetUp()
     {
         self::$container = null;
         foreach ($this->getDataArray() as $manager => $data) {
@@ -149,7 +152,7 @@ abstract class AbstractElasticsearchTestCase extends WebTestCase
     /**
      * {@inheritdoc}
      */
-    protected function tearDown()
+    protected function doTearDown()
     {
         parent::tearDown();
 

--- a/Tests/Functional/Mapping/MetadataCollectorTest.php
+++ b/Tests/Functional/Mapping/MetadataCollectorTest.php
@@ -14,9 +14,12 @@ namespace ONGR\ElasticsearchBundle\Tests\Functional\Mapping;
 use ONGR\ElasticsearchBundle\Exception\MissingDocumentAnnotationException;
 use ONGR\ElasticsearchBundle\Mapping\MetadataCollector;
 use ONGR\ElasticsearchBundle\Tests\WebTestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 class MetadataCollectorTest extends WebTestCase
 {
+    use SetUpTearDownTrait;
+
     /**
      * @var MetadataCollector
      */
@@ -25,7 +28,7 @@ class MetadataCollectorTest extends WebTestCase
     /**
      * Initialize MetadataCollector.
      */
-    public function setUp()
+    public function doSetUp()
     {
         $container = $this->createClient()->getContainer();
         $this->metadataCollector = $container->get('es.metadata_collector');

--- a/Tests/Unit/Mapping/DocumentParserTest.php
+++ b/Tests/Unit/Mapping/DocumentParserTest.php
@@ -14,9 +14,12 @@ namespace ONGR\ElasticsearchBundle\Tests\Unit\Mapping;
 use ONGR\ElasticsearchBundle\Mapping\DocumentParser;
 use ONGR\ElasticsearchBundle\Tests\app\fixture\TestBundle\Document\LongDescriptionTrait;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 class DocumentParserTest extends TestCase
 {
+    use SetUpTearDownTrait;
+
     /*
      * @var \Doctrine\Common\Annotations\Reader
      */
@@ -27,7 +30,7 @@ class DocumentParserTest extends TestCase
      */
     private $finder;
 
-    public function setUp()
+    public function doSetUp()
     {
         $this->reader = $this->getMockBuilder('Doctrine\Common\Annotations\Reader')
             ->disableOriginalConstructor()

--- a/Tests/Unit/Mapping/MetadataCollectorTest.php
+++ b/Tests/Unit/Mapping/MetadataCollectorTest.php
@@ -16,9 +16,12 @@ use ONGR\ElasticsearchBundle\Mapping\DocumentFinder;
 use ONGR\ElasticsearchBundle\Mapping\DocumentParser;
 use ONGR\ElasticsearchBundle\Mapping\MetadataCollector;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 class MetadataCollectorTest extends TestCase
 {
+    use SetUpTearDownTrait;
+
     /**
      * @var MetadataCollector
      */
@@ -42,7 +45,7 @@ class MetadataCollectorTest extends TestCase
     /**
      * Initialize MetadataCollector.
      */
-    public function setUp()
+    public function doSetUp()
     {
         $this->docFinder = $this->getMockBuilder('ONGR\ElasticsearchBundle\Mapping\DocumentFinder')
             ->disableOriginalConstructor()

--- a/Tests/Unit/Result/ConverterTest.php
+++ b/Tests/Unit/Result/ConverterTest.php
@@ -16,9 +16,12 @@ use ONGR\ElasticsearchBundle\Mapping\MetadataCollector;
 use ONGR\ElasticsearchBundle\Result\Converter;
 use ONGR\ElasticsearchBundle\Tests\app\fixture\TestBundle\Document\Product;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 class ConverterTest extends TestCase
 {
+    use SetUpTearDownTrait;
+
     /**
      * @var MetadataCollector
      */
@@ -32,7 +35,7 @@ class ConverterTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function doSetUp()
     {
         $this->metadataCollector = $this->getMockBuilder('ONGR\ElasticsearchBundle\Mapping\MetadataCollector')
             ->disableOriginalConstructor()

--- a/Tests/Unit/Service/GenerateServiceTest.php
+++ b/Tests/Unit/Service/GenerateServiceTest.php
@@ -5,10 +5,13 @@ namespace ONGR\ElasticsearchBundle\Tests\Unit\Generator;
 use ONGR\ElasticsearchBundle\Generator\DocumentGenerator;
 use ONGR\ElasticsearchBundle\Service\GenerateService;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use Symfony\Component\Filesystem\Filesystem;
 
 class GenerateServiceTest extends TestCase
 {
+    use SetUpTearDownTrait;
+
     /**
      * @var string
      */
@@ -22,7 +25,7 @@ class GenerateServiceTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    public function doSetUp()
     {
         $this->tmpDir = sys_get_temp_dir() . '/ongr';
 
@@ -33,7 +36,7 @@ class GenerateServiceTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function tearDown()
+    public function doTearDown()
     {
         $this->filesystem->remove($this->tmpDir);
     }

--- a/Tests/Unit/Service/Json/JsonWriterTest.php
+++ b/Tests/Unit/Service/Json/JsonWriterTest.php
@@ -14,13 +14,16 @@ namespace ONGR\ElasticsearchBundle\Tests\Unit\Service\Json;
 use ONGR\ElasticsearchBundle\Service\Json\JsonWriter;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 class JsonWriterTest extends TestCase
 {
+    use SetUpTearDownTrait;
+
     /**
      * {@inheritdoc}
      */
-    public static function setUpBeforeClass()
+    public static function doSetUpBeforeClass()
     {
         parent::setUpBeforeClass();
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "elasticsearch/elasticsearch": "~5.0|~6.0|~7.0",
         "mikey179/vfsstream": "~1.4",
         "squizlabs/php_codesniffer": "~2.0",
-        "satooshi/php-coveralls": "~1.0",
+        "satooshi/php-coveralls": "~1.0 || ~2.0",
         "symfony/browser-kit" : "^3.4|^4|^5",
         "symfony/expression-language" : "^3.4|^4|^5",
         "symfony/twig-bundle": "^3.4|^4|^5",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,7 +24,6 @@
 
     <php>
         <server name="KERNEL_DIR" value="Tests/app/" />
-        <env name="SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT" value="true"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
 


### PR DESCRIPTION
# TODO

 - [ ] BC Layer class for DataCollector (see BaseEvent as Example)
 - [ ] Update all Commands to Dependency Injection

/cc @prokyonn the tests are now fixed in #3 so we can now test what is needed for Symfony 5 compatibility. I did patch the Events but what we also need todo is changing the Commands to Dependency Injection this should also be possible with Symfony 3.4.