### PR TITLE
Move Repository creation into own compiler pass

### DIFF
--- a/DependencyInjection/Compiler/MappingPass.php
+++ b/DependencyInjection/Compiler/MappingPass.php
@@ -30,8 +30,6 @@ class MappingPass implements CompilerPassInterface
         $analysis = $container->getParameter('es.analysis');
         $managers = $container->getParameter('es.managers');
 
-        $collector = $container->get('es.metadata_collector');
-
         foreach ($managers as $managerName => $manager) {
             $connection = $manager['index'];
             $managerName = strtolower($managerName);
@@ -64,31 +62,6 @@ class MappingPass implements CompilerPassInterface
                     $container->getAlias('es.manager')
                         ->setPublic(true);
                 }
-            }
-
-            $mappings = $collector->getMappings($manager['mappings']);
-
-            // Building repository services.
-            foreach ($mappings as $repositoryType => $repositoryDetails) {
-                $repositoryDefinition = new Definition(
-                    'ONGR\ElasticsearchBundle\Service\Repository',
-                    [$repositoryDetails['namespace']]
-                );
-                $repositoryDefinition->setPublic(true);
-
-                if (isset($repositoryDetails['directory_name']) && $managerName == 'default') {
-                    $container->get('es.document_finder')->setDocumentDir($repositoryDetails['directory_name']);
-                }
-
-                $repositoryDefinition->setFactory(
-                    [
-                        new Reference(sprintf('es.manager.%s', $managerName)),
-                        'getRepository',
-                    ]
-                );
-
-                $repositoryId = sprintf('es.manager.%s.%s', $managerName, $repositoryType);
-                $container->setDefinition($repositoryId, $repositoryDefinition);
             }
         }
     }

--- a/DependencyInjection/Compiler/RepositoryPass.php
+++ b/DependencyInjection/Compiler/RepositoryPass.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * Compiles elastic search data.
+ */
+class RepositoryPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $managers = $container->getParameter('es.managers');
+
+        $collector = $container->get('es.metadata_collector');
+
+        foreach ($managers as $managerName => $manager) {
+            $mappings = $collector->getMappings($manager['mappings']);
+
+            // Building repository services.
+            foreach ($mappings as $repositoryType => $repositoryDetails) {
+                $repositoryDefinition = new Definition(
+                    'ONGR\ElasticsearchBundle\Service\Repository',
+                    [$repositoryDetails['namespace']]
+                );
+                $repositoryDefinition->setPublic(true);
+
+                if (isset($repositoryDetails['directory_name']) && $managerName == 'default') {
+                    $container->get('es.document_finder')->setDocumentDir($repositoryDetails['directory_name']);
+                }
+
+                $repositoryDefinition->setFactory(
+                    [
+                        new Reference(sprintf('es.manager.%s', $managerName)),
+                        'getRepository',
+                    ]
+                );
+
+                $repositoryId = sprintf('es.manager.%s.%s', $managerName, $repositoryType);
+                $container->setDefinition($repositoryId, $repositoryDefinition);
+            }
+        }
+    }
+}

--- a/ONGRElasticsearchBundle.php
+++ b/ONGRElasticsearchBundle.php
@@ -13,6 +13,7 @@ namespace ONGR\ElasticsearchBundle;
 
 use ONGR\ElasticsearchBundle\DependencyInjection\Compiler\ManagerPass;
 use ONGR\ElasticsearchBundle\DependencyInjection\Compiler\MappingPass;
+use ONGR\ElasticsearchBundle\DependencyInjection\Compiler\RepositoryPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -29,8 +30,10 @@ class ONGRElasticsearchBundle extends Bundle
     {
         parent::build($container);
 
-        // MappingPass need to be behind the Symfony `DecoratorServicePass` to allow decorating the annotation reader
-        $container->addCompilerPass(new MappingPass(), PassConfig::TYPE_OPTIMIZE, -10);
-        $container->addCompilerPass(new ManagerPass(), PassConfig::TYPE_OPTIMIZE, -11);
+        $container->addCompilerPass(new MappingPass());
+        $container->addCompilerPass(new ManagerPass());
+        // The `RepositoryPass` need to be behind the Symfony `DecoratorServicePass`
+        // to allow decorating the annotation reader
+        $container->addCompilerPass(new RepositoryPass(), PassConfig::TYPE_OPTIMIZE, -10);
     }
 }

--- a/Tests/Unit/DependencyInjection/Compiler/MappingPassTest.php
+++ b/Tests/Unit/DependencyInjection/Compiler/MappingPassTest.php
@@ -12,6 +12,7 @@
 namespace ONGR\ElasticsearchBundle\Tests\Unit\DependencyInjection\Compiler;
 
 use ONGR\ElasticsearchBundle\DependencyInjection\Compiler\MappingPass;
+use ONGR\ElasticsearchBundle\DependencyInjection\Compiler\RepositoryPass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Alias;
 
@@ -69,7 +70,7 @@ class MappingPassTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $containerMock->expects($this->exactly(2))->method('getParameter')->with($this->anything())
+        $containerMock->expects($this->exactly(3))->method('getParameter')->with($this->anything())
             ->will(
                 $this->returnCallback(
                     function ($parameter) use ($managers) {
@@ -96,6 +97,7 @@ class MappingPassTest extends TestCase
                     }
                 )
             );
+
         $containerMock
             ->expects($this->exactly(2))
             ->method('setDefinition')
@@ -132,7 +134,11 @@ class MappingPassTest extends TestCase
      */
     public function testProcessWithSeveralManagers(array $managers)
     {
+        $container = $this->getContainerMock($managers);
+
         $compilerPass = new MappingPass();
-        $compilerPass->process($this->getContainerMock($managers));
+        $compilerPass->process($container);
+        $compilerPass = new RepositoryPass();
+        $compilerPass->process($container);
     }
 }


### PR DESCRIPTION
ManagerPass and MappingPass need to stay with the priority we need to create the `Repositories` in an own CompilerPass to avoid errors in `lint:container`. 