### PR TITLE
Fix ONGRElasticsearchExtension with multiple mappings with config

### DIFF
--- a/DependencyInjection/ONGRElasticsearchExtension.php
+++ b/DependencyInjection/ONGRElasticsearchExtension.php
@@ -44,7 +44,7 @@ class ONGRElasticsearchExtension extends Extension
 
         $managers = $config['managers'];
         foreach ($managers as &$manager) {
-            $manager['mappings'] = array_unique($manager['mappings']);
+            $manager['mappings'] = array_unique($manager['mappings'], SORT_REGULAR);
         }
         $container->setParameter('es.cache', $config['cache']);
         $container->setParameter('es.analysis', $config['analysis']);


### PR DESCRIPTION
A mapping config like the following leads to a `Warning: Array to string conversion`

```php
[
    'mappings' => [
        0 => 'SuluArticleBundle',
        'MyOtherBundle' => [
            'document_dir' => 'Other/Domain/Document',
        ],
    ],
]
```
