### PR TITLE
Add support for "App" mappings without a Bundle class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /composer.lock
 /var/cache/
 .phpunit.result.cache
+/.idea/

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -47,6 +47,7 @@ class Configuration implements ConfigurationInterface
                     'If profiler is disabled the tracer service will be disabled as well.'
                 )
             ->end()
+            ->scalarNode('app_root_class')->defaultValue('App\\Kernel')->end()
             ->append($this->getAnalysisNode())
             ->append($this->getManagersNode())
             ->end();

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -47,7 +47,7 @@ class Configuration implements ConfigurationInterface
                     'If profiler is disabled the tracer service will be disabled as well.'
                 )
             ->end()
-            ->scalarNode('app_root_class')->defaultValue('App\\Kernel')->end()
+            ->scalarNode('app_root_class')->defaultValue(\class_exists('App\\AppBundle') ? null : 'App\\Kernel')->end()
             ->append($this->getAnalysisNode())
             ->append($this->getManagersNode())
             ->end();

--- a/DependencyInjection/ONGRElasticsearchExtension.php
+++ b/DependencyInjection/ONGRElasticsearchExtension.php
@@ -49,7 +49,7 @@ class ONGRElasticsearchExtension extends Extension
         $container->setParameter('es.cache', $config['cache']);
         $container->setParameter('es.analysis', $config['analysis']);
         $container->setParameter('es.managers', $managers);
-        $container->setParameter('es.app_root_class', $config['app_root_class'] ?? 'App\\Kernel');
+        $container->setParameter('es.app_root_class', $config['app_root_class'] ?? null);
         $definition = new Definition(
             'ONGR\ElasticsearchBundle\Service\ManagerFactory',
             [

--- a/DependencyInjection/ONGRElasticsearchExtension.php
+++ b/DependencyInjection/ONGRElasticsearchExtension.php
@@ -49,6 +49,7 @@ class ONGRElasticsearchExtension extends Extension
         $container->setParameter('es.cache', $config['cache']);
         $container->setParameter('es.analysis', $config['analysis']);
         $container->setParameter('es.managers', $managers);
+        $container->setParameter('es.app_root_class', $config['app_root_class'] ?? 'App\\Kernel');
         $definition = new Definition(
             'ONGR\ElasticsearchBundle\Service\ManagerFactory',
             [

--- a/Mapping/DocumentFinder.php
+++ b/Mapping/DocumentFinder.php
@@ -11,8 +11,6 @@
 
 namespace ONGR\ElasticsearchBundle\Mapping;
 
-use function class_exists;
-
 /**
  * Finds documents in bundles.
  */
@@ -36,12 +34,12 @@ class DocumentFinder
      *                             This is to ensure the fake bundle "App" can be used for mappings.
      *                             It is not a perfect solution but the easiest.
      */
-    public function __construct(array $bundles, string $appRootClass = 'App\\Kernel')
+    public function __construct(array $bundles, ?string $appRootClass = null)
     {
         $this->documentDir = 'Document';
         $this->bundles = $bundles;
 
-        if (!empty($appRootClass) && class_exists($appRootClass)) {
+        if ($appRootClass && \class_exists($appRootClass) && !isset($this->bundles['App']) && !isset($this->bundles['AppBundle'])) {
             $this->bundles['App'] = $appRootClass;
         }
     }

--- a/Mapping/DocumentFinder.php
+++ b/Mapping/DocumentFinder.php
@@ -30,7 +30,8 @@ class DocumentFinder
      * Constructor.
      *
      * @param array $bundles Parameter kernel.bundles from service container.
-     * @param string $appRootClass A class that has to be in the app's root folder. By default, the app's kernel class is used.
+     * @param string $appRootClass A class that has to be in the app's root folder.
+     *                             By default, the app's kernel class is used.
      *                             This is to ensure the fake bundle "App" can be used for mappings.
      *                             It is not a perfect solution but the easiest.
      */
@@ -39,7 +40,8 @@ class DocumentFinder
         $this->documentDir = 'Document';
         $this->bundles = $bundles;
 
-        if ($appRootClass && \class_exists($appRootClass) && !isset($this->bundles['App']) && !isset($this->bundles['AppBundle'])) {
+        if ($appRootClass && \class_exists($appRootClass) &&
+            !isset($this->bundles['App']) && !isset($this->bundles['AppBundle'])) {
             $this->bundles['App'] = $appRootClass;
         }
     }

--- a/Mapping/DocumentFinder.php
+++ b/Mapping/DocumentFinder.php
@@ -11,6 +11,8 @@
 
 namespace ONGR\ElasticsearchBundle\Mapping;
 
+use function class_exists;
+
 /**
  * Finds documents in bundles.
  */
@@ -30,11 +32,18 @@ class DocumentFinder
      * Constructor.
      *
      * @param array $bundles Parameter kernel.bundles from service container.
+     * @param string $appRootClass A class that has to be in the app's root folder. By default, the app's kernel class is used.
+     *                             This is to ensure the fake bundle "App" can be used for mappings.
+     *                             It is not a perfect solution but the easiest.
      */
-    public function __construct(array $bundles)
+    public function __construct(array $bundles, string $appRootClass = 'App\\Kernel')
     {
         $this->documentDir = 'Document';
         $this->bundles = $bundles;
+
+        if (!empty($appRootClass) && class_exists($appRootClass)) {
+            $this->bundles['App'] = $appRootClass;
+        }
     }
 
     /**

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,4 +1,5 @@
 parameters:
+    es.app_root_class: 'App\Kernel'
     es.logging.path: "%kernel.logs_dir%/elasticsearch_%kernel.environment%.log"
 
 services:
@@ -27,7 +28,7 @@ services:
     es.document_finder:
         class: 'ONGR\ElasticsearchBundle\Mapping\DocumentFinder'
         public: true
-        arguments: ["%kernel.bundles%"]
+        arguments: ["%kernel.bundles%", "%es.app_root_class%"]
 
     es.document_parser:
         class: 'ONGR\ElasticsearchBundle\Mapping\DocumentParser'

--- a/Resources/doc/mapping.md
+++ b/Resources/doc/mapping.md
@@ -3,6 +3,21 @@
 Elasticsearch bundle requires mapping definitions for it to work with complex operations,
 like insert and update documents, do a full-text search, etc.
 
+### App mapping
+
+In order for the app's classes to be mapped a fake bundle with the name `App` is added. This is not a perfect solution but was the easiest to implement and add support for it.
+
+It requires a class in the project's source root folder.
+
+By default, the `App\kernel` class is used. This class can be changed to any other class by using the configuration:
+
+```yaml
+ongr_elasticsearch:
+  app_root_class: 'App\FakeAppRoot'
+```
+
+The referenced class has to exist as it is used with various ReflectionClass instances to find their folder etc., but can otherwise be empty. If the class does not exist, no mappings for `App` can be configured.
+
 ### Mapping configuration
 
 Here's an example of configuration containing the definitions of filter and analyzer:
@@ -29,7 +44,7 @@ ongr_elasticsearch:
                 hosts:
                     - 127.0.0.1:9200
             mappings:
-                - AppBundle
+                - App
 ```
 
 From 5.0 version mapping was enchased, and now you can change documents directory. See the example below:
@@ -43,7 +58,7 @@ From 5.0 version mapping was enchased, and now you can change documents director
                 hosts:
                     - 127.0.0.1:9200
             mappings:
-                AppBundle: ~ #Document dir will be Document.
+                App: ~ #Document dir will be Document.
                 CustomBundle:
                     document_dir: Entity #For this bundle will search documents in the Entity.
                     
@@ -53,7 +68,7 @@ From 5.0 version mapping was enchased, and now you can change documents director
                 hosts:
                     - 127.0.0.1:9200
             mappings:
-                - AppBundle
+                - App
 ```
 
 > Both mappings are valid. In the above example, you can change the directory for the particular
@@ -132,7 +147,7 @@ ongr_elasticsearch:
                 hosts:
                     - 127.0.0.1:9200
             mappings:
-                - AppBundle
+                - App
 ```
 
 ### Document class annotations
@@ -140,9 +155,9 @@ ongr_elasticsearch:
 Lets start with a document class example.
 
 ```php
-// src/AppBundle/Document/Content.php
+// src/App/Document/Content.php
 
-namespace AppBundle\Document;
+namespace App\Document;
 
 use ONGR\ElasticsearchBundle\Annotation as ES;
 
@@ -204,8 +219,8 @@ Analyzers names must be defined in `config.yml` under the `analysis` node (read 
 Here's an example how to add it:
 
 ```php
-// src/AppBundle/Document/Product.php
-namespace AppBundle\Document;
+// src/App/Document/Product.php
+namespace App\Document;
 
 use ONGR\ElasticsearchBundle\Annotation as ES;
 
@@ -238,9 +253,9 @@ To define a nested or object type you have to use `@ES\Embedded` annotation and 
 class for this annotation. Here's an example, lets assume we have a `Product` type with `Variant` object field.
 
 ```php
-// src/AppBundle/Document/Product.php
+// src/App/Document/Product.php
 
-namespace AppBundle\Document;
+namespace App\Document;
 
 use ONGR\ElasticsearchBundle\Annotation as ES;
 
@@ -257,7 +272,7 @@ class Product
     /**
      * @var ContentMetaObject
      *
-     * @ES\Embedded(class="AppBundle:CategoryObject")
+     * @ES\Embedded(class="App\Dcouemnt\CategoryObject")
      */
     private $category;
 
@@ -268,9 +283,9 @@ class Product
 And the `Category` object will look like:
 
 ```php
-// src/AppBundle/Document/CategoryObject.php
+// src/App/Document/CategoryObject.php
 
-namespace AppBundle\Document;
+namespace App\Document;
 
 use ONGR\ElasticsearchBundle\Annotation as ES;
 
@@ -342,9 +357,9 @@ initiating a document with multiple items you need to initialize property with t
 Here's an example:
 
 ```php
-// src/AppBundle/Document/Product.php
+// src/App/Document/Product.php
 
-namespace AppBundle\Document;
+namespace App\Document;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use ONGR\ElasticsearchBundle\Annotation as ES;
@@ -362,7 +377,7 @@ class Product
     /**
      * @var ContentMetaObject
      *
-     * @ES\Embedded(class="AppBundle:VariantObject", multiple=true)
+     * @ES\Embedded(class="App\Document\VariantObject", multiple=true)
      */
     private $variants;
     
@@ -392,9 +407,9 @@ And the object:
 
 
 ```php
-// src/AppBundle/Document/VariantObject.php
+// src/App/Document/VariantObject.php
 
-namespace AppBundle\Document;
+namespace App\Document;
 
 use ONGR\ElasticsearchBundle\Annotation as ES;
 

--- a/Resources/doc/mapping.md
+++ b/Resources/doc/mapping.md
@@ -9,11 +9,11 @@ In order for the app's classes to be mapped a fake bundle with the name `App` is
 
 It requires a class in the project's source root folder.
 
-By default, the `App\kernel` class is used. This class can be changed to any other class by using the configuration:
+By default, the `App\Kernel` class is used. This class can be changed to any other class by using the configuration:
 
 ```yaml
 ongr_elasticsearch:
-  app_root_class: 'App\FakeAppRoot'
+  app_root_class: 'App\YourKernel'
 ```
 
 The referenced class has to exist as it is used with various ReflectionClass instances to find their folder etc., but can otherwise be empty. If the class does not exist, no mappings for `App` can be configured.
@@ -272,7 +272,7 @@ class Product
     /**
      * @var ContentMetaObject
      *
-     * @ES\Embedded(class="App\Dcouemnt\CategoryObject")
+     * @ES\Embedded(class="App\Document\CategoryObject")
      */
     private $category;
 


### PR DESCRIPTION
It is not optimal because it "fakes" a bundle by using a class in the app's source root - by default `App\Kernel` or optionally any other class. The advantage is that in most cases it works out of the box and in some others it can be fixed using a minor configuration change.

The main advantage is, that as there is no bundle configured there will be no unintended side consequences (as I mentioned in the corresponding issue).

Fixes: #15 